### PR TITLE
Send button component when clicked

### DIFF
--- a/addon/components/mdl-button.js
+++ b/addon/components/mdl-button.js
@@ -37,6 +37,6 @@ export default BaseComponent.extend(RippleSupport, {
   },
 
   click() {
-    this.sendAction();
+    this.sendAction(this);
   }
 });


### PR DESCRIPTION
This allows a parent component to set properties on the button that it can then access in the click event. E.g.: `{{mdl-button action=toggleProperty propertyToToggle=myProp}}`

Then in the parent component:

```
actions: {
  toggleProperty(button) {
    this.toggleProperty(button.get('propertyToToggle'));
  }
}
```