### PR TITLE
Remove stylesheet concatenation into vendor.css Fixes #43

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ ember install ember-material-lite
 This addon can be used without SASS (relying on pure CSS for styles). If you choose this path, you'll need to alter your app slightly.
 
 1. Delete the `ember-cli-sass` NPM dependency that the installation blueprint will add to your app.
-2. Your app.css should start with
-```css
-@import "bower_components/material-design-lite/material.css";
+2. Add the following line to your `ember-cli-build.js`.
+```js
+app.import(app.bowerDirectory + '/material-design-lite/material.css');
 ```
 
 ## Configuration

--- a/index.js
+++ b/index.js
@@ -24,7 +24,5 @@ module.exports = {
     app.import(app.bowerDirectory + '/material-design-lite/src/tabs/tabs.js');
     app.import(app.bowerDirectory + '/material-design-lite/src/textfield/textfield.js');
     app.import(app.bowerDirectory + '/material-design-lite/src/tooltip/tooltip.js');
-
-    app.import(app.bowerDirectory + '/material-design-lite/material.css', { destDir: 'material-design-lite/css' });
   }
 };


### PR DESCRIPTION
Now that the CSS files aren't concatenated into `vendor.css`, the instruction on how to use it without SASS needs to be updated, but that will come in a separate PR.