### PR TITLE
[BUGFIX] fixes #29 added normalizeEntityName override to prevent error during install

### DIFF
--- a/blueprints/ember-material-lite/index.js
+++ b/blueprints/ember-material-lite/index.js
@@ -3,6 +3,7 @@ var chalk = require('chalk');
 
 module.exports = {
   description: 'install ember-material-lite into a typical project',
+  normalizeEntityName: function() {}, // no-op since we're just adding dependencies
 
   beforeInstall: function (options) {
     return RSVP.all([


### PR DESCRIPTION
Fixes #29, preventing this error from occurring and stopping the install:
```
The `ember generate <entity-name>` command requires an entity name to be specified. For more details, use `ember help`.
```