### PR TITLE
Fix mdl-button not triggering primary action

### DIFF
--- a/addon/components/mdl-button.js
+++ b/addon/components/mdl-button.js
@@ -36,6 +36,6 @@ export default BaseComponent.extend(RippleSupport, {
   },
 
   click() {
-    this.sendAction(this);
+    this.sendAction('action', this);
   }
 });


### PR DESCRIPTION
The `sendAction` method accepts action name as the first parameter, so passing an (non-string)object as its first paramter causes that object to be the action name.

```
{{mdl-button action="handler"}}
```