### PR TITLE
Add checked property binding on mdl-radio

### DIFF
--- a/addon/components/mdl-radio.js
+++ b/addon/components/mdl-radio.js
@@ -4,6 +4,7 @@ import layout from '../templates/components/mdl-radio';
 export default BaseToggleComponent.extend({
   primaryClassName: 'radio',
   layout,
+  checked: false,
 
   didInsertElement() {
     this._super(...arguments);

--- a/addon/templates/components/mdl-radio.hbs
+++ b/addon/templates/components/mdl-radio.hbs
@@ -1,2 +1,2 @@
-{{input type="radio" id=_inputId class="mdl-radio__button" name="options" value=value disabled=disabled}}
+<input type="radio" id={{_inputId}} class="mdl-radio__button" name="options" value={{value}} disabled={{disabled}} checked={{checked}} />
 <span class="mdl-radio__label">{{label}}{{yield}}</span>

--- a/tests/unit/components/mdl-radio-test.js
+++ b/tests/unit/components/mdl-radio-test.js
@@ -1,3 +1,4 @@
+import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import { componentDisabledTest } from './-general-helpers';
 
@@ -20,3 +21,16 @@ test('it renders', function(assert) {
 });
 
 test('Component disables properly', componentDisabledTest('input'));
+
+test('checked property is set', function(assert) {
+  assert.expect(1);
+
+  // Creates the component instance
+  const component = this.subject({ checked: true });
+
+  // Renders the component to the page
+  this.render();
+
+  // Test the checked state
+  assert.equal(this.$('input').is(':checked'), true);
+});


### PR DESCRIPTION
This also removes the `input` helper use in the `mdl-radio.hbs`, since it doesn't support binding for the `checked` attribute for radio input.