### PR TITLE
Better error messages for mdl-textfield

### DIFF
--- a/addon/components/-base-input-component.js
+++ b/addon/components/-base-input-component.js
@@ -1,13 +1,19 @@
 import Ember from 'ember';
 import BaseComponent from './-base-toplevel-component';
 
-const { computed } = Ember;
+const {
+  computed,
+  isPresent,
+  observer,
+  run
+} = Ember;
 
 export default BaseComponent.extend({
   primaryClassName: 'textfield',
   type: 'text',
   disabled: false,
   isLabelFloating: true,
+  errorMessage: null,
   classNameBindings: [
     'isLabelFloating:mdl-textfield--floating-label'
   ],
@@ -22,5 +28,22 @@ export default BaseComponent.extend({
     this.beforeMdlInit();
     let mdlTextfield = new window.MaterialTextfield(this.get('element'));
     this.set('_mdlComponent', mdlTextfield);
+  },
+  _checkValidity: observer('errorMessage', function() {
+    run.scheduleOnce('afterRender', this, this._setValidity);
+  }),
+  _setValidity() {
+    if (this.isDestroyed) {
+      return;
+    }
+
+    let mdlComponent = this.get('_mdlComponent');
+    let errorMessage = this.get('errorMessage');
+
+    if (isPresent(errorMessage)) {
+      mdlComponent.input_.setCustomValidity(errorMessage.toString());
+    } else {
+      mdlComponent.input_.setCustomValidity('');
+    }
   }
 });

--- a/addon/components/mdl-textfield.js
+++ b/addon/components/mdl-textfield.js
@@ -1,5 +1,11 @@
+import Ember from 'ember';
 import BaseComponent from './-base-input-component';
 import layout from '../templates/components/mdl-textfield';
+
+const {
+  isPresent,
+  observer
+} = Ember;
 
 export default BaseComponent.extend({
   pattern: null,
@@ -12,5 +18,15 @@ export default BaseComponent.extend({
   ],
   beforeMdlInit() {
     this.$('label.mdl-button').attr('for', this.get('_inputId'));
-  }
+  },
+  setValidity: observer('errorMessage', function() {
+    let mdlComponent = this.get('_mdlComponent');
+    let errorMessage = this.get('errorMessage');
+
+    if (isPresent(errorMessage)) {
+      mdlComponent.input_.setCustomValidity(errorMessage.toString());
+    } else {
+      mdlComponent.input_.setCustomValidity('');
+    }
+  })
 });

--- a/addon/components/mdl-textfield.js
+++ b/addon/components/mdl-textfield.js
@@ -1,16 +1,8 @@
-import Ember from 'ember';
 import BaseComponent from './-base-input-component';
 import layout from '../templates/components/mdl-textfield';
 
-const {
-  isPresent,
-  observer,
-  run
-} = Ember;
-
 export default BaseComponent.extend({
   pattern: null,
-  errorMessage: null,
   isExpandable: false,
   expandableIcon: null,
   layout,
@@ -19,22 +11,5 @@ export default BaseComponent.extend({
   ],
   beforeMdlInit() {
     this.$('label.mdl-button').attr('for', this.get('_inputId'));
-  },
-  _checkValidity: observer('errorMessage', function() {
-    run.scheduleOnce('afterRender', this, this._setValidity);
-  }),
-  _setValidity() {
-    if (this.isDestroyed) {
-      return;
-    }
-
-    let mdlComponent = this.get('_mdlComponent');
-    let errorMessage = this.get('errorMessage');
-
-    if (isPresent(errorMessage)) {
-      mdlComponent.input_.setCustomValidity(errorMessage.toString());
-    } else {
-      mdlComponent.input_.setCustomValidity('');
-    }
   }
 });

--- a/addon/components/mdl-textfield.js
+++ b/addon/components/mdl-textfield.js
@@ -4,7 +4,8 @@ import layout from '../templates/components/mdl-textfield';
 
 const {
   isPresent,
-  observer
+  observer,
+  run
 } = Ember;
 
 export default BaseComponent.extend({
@@ -19,7 +20,14 @@ export default BaseComponent.extend({
   beforeMdlInit() {
     this.$('label.mdl-button').attr('for', this.get('_inputId'));
   },
-  setValidity: observer('errorMessage', function() {
+  _checkValidity: observer('errorMessage', function() {
+    run.scheduleOnce('afterRender', this, this._setValidity);
+  }),
+  _setValidity() {
+    if (this.isDestroyed) {
+      return;
+    }
+
     let mdlComponent = this.get('_mdlComponent');
     let errorMessage = this.get('errorMessage');
 
@@ -28,5 +36,5 @@ export default BaseComponent.extend({
     } else {
       mdlComponent.input_.setCustomValidity('');
     }
-  })
+  }
 });

--- a/tests/integration/components/mdl-textarea-test.js
+++ b/tests/integration/components/mdl-textarea-test.js
@@ -1,0 +1,64 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('mdl-textarea', 'Integration | Component | mdl textarea', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+  assert.expect(1);
+
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+
+  this.render(hbs`{{mdl-textarea}}`);
+
+  assert.equal(this.$('textarea').length, 1, 'Rendered a textarea');
+});
+
+test('value bindings', function(assert) {
+  assert.expect(2);
+
+  this.set('value', 'hello');
+
+  this.render(hbs`{{mdl-textarea value=value}}`);
+
+  assert.equal(this.$('textarea').val(), 'hello');
+
+  this.$('textarea').val('bye').change();
+  assert.equal(this.get('value'), 'bye');
+});
+
+test('html validations', function(assert) {
+  assert.expect(2);
+
+  this.render(
+    hbs`{{mdl-textarea pattern="[A-Z]{2}" errorMessage="Please use two upper case letters"}}`
+  );
+
+  this.$('textarea').val('ny').change();
+
+  assert.equal(this.$().text().trim(), 'Please use two upper case letters');
+  assert.ok(this.$('.mdl-textfield__error').is(':visible'), 'Errors are visible');
+});
+
+test('custom errorMessage', function(assert) {
+  assert.expect(5);
+
+  this.render(
+    hbs`{{mdl-textarea errorMessage=message}}`
+  );
+
+  assert.equal(this.$('.mdl-textfield__error').length, 0, 'No errors are visible');
+
+  this.set('message', 'That text is not acceptable');
+
+  assert.equal(this.$().text().trim(), 'That text is not acceptable');
+  assert.ok(this.$('.mdl-textfield__error').is(':visible'), 'Errors are visible');
+
+  this.set('message', '');
+  assert.equal(this.$('.mdl-textfield__error').length, 0, 'No errors are visible');
+
+  this.set('message', []);
+  assert.equal(this.$('.mdl-textfield__error').length, 0, 'No errors are visible');
+});

--- a/tests/integration/components/mdl-textfield-test.js
+++ b/tests/integration/components/mdl-textfield-test.js
@@ -1,0 +1,43 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('mdl-textfield', 'Integration | Component | mdl textfield', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+  assert.expect(1);
+
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+
+  this.render(hbs`{{mdl-textfield}}`);
+
+  assert.equal(this.$('input').length, 1, 'Rendered an input');
+});
+
+test('value bindings', function(assert) {
+  assert.expect(2);
+
+  this.set('value', 'hello');
+
+  this.render(hbs`{{mdl-textfield value=value}}`);
+
+  assert.equal(this.$('input').val(), 'hello');
+
+  this.$('input').val('bye').change();
+  assert.equal(this.get('value'), 'bye');
+});
+
+test('html validations', function(assert) {
+  assert.expect(2);
+
+  this.render(
+    hbs`{{mdl-textfield pattern="[A-Z]{2}" errorMessage="Please use two upper case letters"}}`
+  );
+
+  this.$('input').val('ny').change();
+
+  assert.equal(this.$().text().trim(), 'Please use two upper case letters');
+  assert.ok(this.$('.mdl-textfield__error').is(':visible'), 'Errors are visible');
+});

--- a/tests/integration/components/mdl-textfield-test.js
+++ b/tests/integration/components/mdl-textfield-test.js
@@ -41,3 +41,24 @@ test('html validations', function(assert) {
   assert.equal(this.$().text().trim(), 'Please use two upper case letters');
   assert.ok(this.$('.mdl-textfield__error').is(':visible'), 'Errors are visible');
 });
+
+test('custom errorMessage', function(assert) {
+  assert.expect(5);
+
+  this.render(
+    hbs`{{mdl-textfield errorMessage=message}}`
+  );
+
+  assert.equal(this.$('.mdl-textfield__error').length, 0, 'No errors are visible');
+
+  this.set('message', 'That input is not acceptable');
+
+  assert.equal(this.$().text().trim(), 'That input is not acceptable');
+  assert.ok(this.$('.mdl-textfield__error').is(':visible'), 'Errors are visible');
+
+  this.set('message', '');
+  assert.equal(this.$('.mdl-textfield__error').length, 0, 'No errors are visible');
+
+  this.set('message', []);
+  assert.equal(this.$('.mdl-textfield__error').length, 0, 'No errors are visible');
+});


### PR DESCRIPTION
I added support for binding `errorMessage` to something coming from outside the component. Lets say you have existing validations or server-side validations and want to provide feedback to the user, the simple `pattern` approach provided by the `HTMLInputElement` doesn't work.

This approach simply observes the `errorMessage` property, sanitises the value slightly, and calls the `HTMLInputElement`'s `setCustomValidity`, which in turns triggers MDL to do its thing and apply the correct `is-invalid` class to the wrapping div...

Pending initial feedback I'll get this implemented on `{{mdl-textarea}}` too.