### PR TITLE
Adds instructions for including local icon fonts

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,49 @@ $color-accent: $palette-pink-A200;
 @import "material-design-lite";
 ```
 
+## Load Material design icons fontfiles locally
+Adding `http://fonts.googleapis.com/icon?family=Material+Icons` into the `index.html` just works.
+But in few scenarios(like running app offline) you would want to include these icon fonts from the project directories itself. 
+To achieve the same, first edit `ember-cli-build.js` to include the following
+
+```js
+var EmberApp = require('ember-cli/lib/broccoli/ember-app');
+var mergeTrees = require('broccoli-merge-trees');
+var pickFiles = require('broccoli-static-compiler');
+
+module.exports = function(defaults) {
+  var app = new EmberApp(defaults, {
+    sassOptions: {
+      includePaths: ['bower_components/material-design-lite/src']
+    }    
+  });
+
+  var googleFontFiles = pickFiles('bower_components/material-design-icons/iconfont', {
+    srcDir: '/',
+    files: ['**/*.woff', '**/*.woff2', '**/*.eot', '**/*.ttf'],
+    destDir: '/fonts'
+  });
+
+  return mergeTrees([app.toTree(), googleFontFiles]);
+};
+```
+
+Also Add below code on top of `app/styles/app.scss` file to import icon font files.
+```css
+/*Material Icons css*/
+@font-face {
+  font-family: 'Material Icons';
+  font-style: normal;
+  font-weight: 400;
+  src: url(../fonts/MaterialIcons-Regular.eot); /* For IE6-8 */
+  src: local('Material Icons'),
+       local('MaterialIcons-Regular'),
+       url(../fonts/MaterialIcons-Regular.woff2) format('woff2'),
+       url(../fonts/MaterialIcons-Regular.woff) format('woff'),
+       url(../fonts/MaterialIcons-Regular.ttf) format('truetype');
+}
+```
+
 ## Running Tests
 
 * `ember test`


### PR DESCRIPTION
Few scenarios like running offline app requires to load material icon font file from project folders. This pull request adds instruction for including these fonts files from using brocolli .

Addressing the issue https://github.com/mike-north/ember-material-lite/issues/74