### PR TITLE
Add name attr binding to input fields

### DIFF
--- a/addon/templates/components/mdl-checkbox.hbs
+++ b/addon/templates/components/mdl-checkbox.hbs
@@ -1,2 +1,2 @@
-{{input type="checkbox" id=_inputId class="mdl-checkbox__input" checked=value click='onToggle' disabled=disabled}}
+{{input type="checkbox" id=_inputId class="mdl-checkbox__input" checked=value click='onToggle' disabled=disabled name=name}}
 <span class="mdl-checkbox__label">{{text}}{{yield}}</span>

--- a/addon/templates/components/mdl-icon-toggle.hbs
+++ b/addon/templates/components/mdl-icon-toggle.hbs
@@ -1,2 +1,2 @@
-{{input type="checkbox" id=_inputId class="mdl-icon-toggle__input" checked=value}}
+{{input type="checkbox" id=_inputId class="mdl-icon-toggle__input" checked=value name=name}}
 <span class="mdl-icon-toggle__label material-icons">{{icon}}</span>

--- a/addon/templates/components/mdl-switch.hbs
+++ b/addon/templates/components/mdl-switch.hbs
@@ -1,2 +1,2 @@
-{{input type="checkbox" id=_inputId class="mdl-switch__input" checked=value}}
+{{input type="checkbox" id=_inputId class="mdl-switch__input" checked=value name=name}}
 <span class="mdl-switch__label">{{text}}{{yield}}</span>

--- a/addon/templates/components/mdl-textarea.hbs
+++ b/addon/templates/components/mdl-textarea.hbs
@@ -1,4 +1,4 @@
-{{textarea class="mdl-textfield__input" id=_inputId disabled=disabled value=value}}
+{{textarea class="mdl-textfield__input" id=_inputId disabled=disabled value=value name=name}}
 
 <label class="mdl-textfield__label">{{label}}</label>
 {{#if errorMessage}}

--- a/addon/templates/components/mdl-textfield.hbs
+++ b/addon/templates/components/mdl-textfield.hbs
@@ -1,14 +1,14 @@
 {{#if isExpandable}}
   {{mdl-button for=elementId tagName='label' icon=expandableIcon  hasRipples=false isColored=false}}
   <div class="mdl-textfield__expandable-holder">
-    {{input class="mdl-textfield__input" type=type pattern=pattern id=_inputId disabled=disabled value=value}}
+    {{input class="mdl-textfield__input" type=type pattern=pattern id=_inputId disabled=disabled value=value name=name}}
     <label class="mdl-textfield__label" for="{{_inputId}}">{{label}}</label>
     {{#if errorMessage}}
       <span class="mdl-textfield__error">{{errorMessage}}</span>
     {{/if}}
   </div>
 {{else}}
-  {{input class="mdl-textfield__input" type=type pattern=pattern id=_inputId disabled=disabled value=value}}
+  {{input class="mdl-textfield__input" type=type pattern=pattern id=_inputId disabled=disabled value=value name=name}}
   <label class="mdl-textfield__label">{{label}}</label>
   {{#if errorMessage}}
     <span class="mdl-textfield__error">{{errorMessage}}</span>


### PR DESCRIPTION
For testing inputs and accessibility, name binding should be passed through to inputs.