### PR TITLE
run setValidity on insertion, updateClasses when setting validity

### DIFF
--- a/addon/components/-base-input-component.js
+++ b/addon/components/-base-input-component.js
@@ -28,6 +28,7 @@ export default BaseComponent.extend({
     this.beforeMdlInit();
     let mdlTextfield = new window.MaterialTextfield(this.get('element'));
     this.set('_mdlComponent', mdlTextfield);
+    this._setValidity();
   },
   _checkValidity: observer('errorMessage', function() {
     run.scheduleOnce('afterRender', this, this._setValidity);
@@ -45,5 +46,8 @@ export default BaseComponent.extend({
     } else {
       mdlComponent.input_.setCustomValidity('');
     }
+
+    mdlComponent.updateClasses_();
+    mdlComponent.checkDirty();
   }
 });


### PR DESCRIPTION
this helps set errors by changing `errorMessage` - otherwise the error message is ignored until the user starts typing