### PR TITLE
Bug: any mdl input component with floating label doesn't update css c…

### DIFF
--- a/addon/components/-base-input-component.js
+++ b/addon/components/-base-input-component.js
@@ -29,6 +29,14 @@ export default BaseComponent.extend({
     let mdlTextfield = new window.MaterialTextfield(this.get('element'));
     this.set('_mdlComponent', mdlTextfield);
   },
+
+	didUpdate() {
+		Ember.run.scheduleOnce('afterRender', this, () => {
+			this.get('_mdlComponent').updateClasses_();
+		});
+		return this._super(...arguments);
+	},
+
   _checkValidity: observer('errorMessage', function() {
     run.scheduleOnce('afterRender', this, this._setValidity);
   }),


### PR DESCRIPTION
…lasses after long time promise resolve

Case: use {{mdl-textfield}} with floating label. When long promise has been resolved, new value for textfield has set by javascript and any change event doesn't triggered. So css classes hasn't updated.

Fix: after update manualy run updateClasses_

But in this fix there is a problem to separate user and system changes, so for user changes css classes should updated twice.