### PR TITLE
Enable binding for "step" on mdl-slider

### DIFF
--- a/addon/components/mdl-slider.js
+++ b/addon/components/mdl-slider.js
@@ -7,7 +7,7 @@ export default BaseComponent.extend({
   min: 0,
   max: 100,
   value: 0,
-  attributeBindings: ['type', 'min', 'max', 'value'],
+  attributeBindings: ['type', 'min', 'max', 'value', 'step'],
   primaryClassName: 'slider',
   layout,
   didInsertElement() {


### PR DESCRIPTION
This change enables the use of HTML5 step property.
Needed for decimal or bigger than 1 step definitions.

https://html.spec.whatwg.org/multipage/forms.html#attr-input-step