### PR TITLE
Use double quotes in blueprint components

### DIFF
--- a/blueprints/ember-material-lite/files/app/index.html
+++ b/blueprints/ember-material-lite/files/app/index.html
@@ -7,20 +7,20 @@
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    {{content-for 'head'}}
+    {{content-for "head"}}
 
     <link rel="stylesheet" href="assets/vendor.css">
     <link rel="stylesheet" href="assets/<%= dasherizedPackageName %>.css">
 
     <link rel="stylesheet" href="//fonts.googleapis.com/icon?family=Material+Icons">
-    {{content-for 'head-footer'}}
+    {{content-for "head-footer"}}
   </head>
   <body>
-    {{content-for 'body'}}
+    {{content-for "body"}}
 
     <script src="assets/vendor.js"></script>
     <script src="assets/<%= dasherizedPackageName %>.js"></script>
 
-    {{content-for 'body-footer'}}
+    {{content-for "body-footer"}}
   </body>
 </html>


### PR DESCRIPTION
On ember install I had a index.html diff with single/double quote clashes

See ember-cli/ember-cli#5192