### PR TITLE
Added isNonNumeric attribute to mdl-table-col

### DIFF
--- a/addon/components/mdl-table-col.js
+++ b/addon/components/mdl-table-col.js
@@ -10,6 +10,7 @@ export default BaseComponent.extend(ChildComponentSupport, {
   _parentComponentTypes: new A([MdlTable]),
   tagName: 'td',
   layout,
+  clssNameBindings: ['isNonNumeric:mdl-data-table__cell--non-numeric'],
   shouldRegisterToParent(parentComponent) {
     const childComponents = parentComponent.getComposableChildren();
     if (isEmpty(childComponents)) {

--- a/addon/templates/components/mdl-table.hbs
+++ b/addon/templates/components/mdl-table.hbs
@@ -1,7 +1,11 @@
 <thead>
 	<tr>
 	{{#each composableChildren as |child|}}
-		<th>{{child.label}}</th>
+		{{#if child.isNonNumeric}}
+			<th class="mdl-data-table__cell--non-numeric">{{child.label}}</th>
+		{{else}}
+			<th>{{child.label}}</th>
+		{{/if}}
 	{{/each}}		
 	</tr>
 </thead>

--- a/tests/integration/components/mdl-table-test.js
+++ b/tests/integration/components/mdl-table-test.js
@@ -26,7 +26,7 @@ test('it renders', function(assert) {
       {{#mdl-table-col label='Id'}}
         {{row.id}}
       {{/mdl-table-col}}
-      {{#mdl-table-col label='Name'}}
+      {{#mdl-table-col label='Name' isNonNumeric=true}}
         {{row.name}}
       {{/mdl-table-col}}
     {{/mdl-table}}


### PR DESCRIPTION
Added isNonNumeric attribute to mdl-table-col to properly align table items according to their type. This issue was already discussed in #90 