### PR TITLE
Update mdl to latest version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-material-lite",
   "dependencies": {
-    "material-design-lite": "1.0.6"
+    "material-design-lite": "1.3.0"
   }
 }


### PR DESCRIPTION
Thanks for contributing to this library! Please make sure that

- [ ] You've written some tests to go along with your code
- [ ] The automated testing passes successfully
- [ ] You've updated the documentation (the dummy app for this addon) as appropriate
- [ ] You've provided an explanation as to what this feature/fix does, so that others can understand the intent while reviewing the code
---

I'm currently running a project and have pinned material-design-lite to 1.3.0 in my bower.json. When using this version I get a ReferenceError for mdl-tooltip (see screenshot) because MDL refactored an internal function name in version 1.2 while this repo is using a version before the refactor. If I pin my bower.json material-design-lite to the same version as this repo I get some pretty crazy styling issues.

If this doesn't present test breakage or any BC concerns it would be great to get this merged in to fix mdl-tooltip for those of us using a more recent version of MDL.