### PR TITLE
Add required, autofocus attrs to mdl-textarea, mdl-textfield

### DIFF
--- a/addon/templates/components/mdl-textarea.hbs
+++ b/addon/templates/components/mdl-textarea.hbs
@@ -1,4 +1,11 @@
-{{textarea class="mdl-textfield__input" id=_inputId disabled=disabled value=value}}
+{{textarea
+  class="mdl-textfield__input"
+  id=_inputId
+  autofocus=autofocus
+  disabled=disabled
+  required=required
+  rows=rows
+  value=value}}
 
 <label class="mdl-textfield__label">{{label}}</label>
 {{#if errorMessage}}

--- a/addon/templates/components/mdl-textfield.hbs
+++ b/addon/templates/components/mdl-textfield.hbs
@@ -1,14 +1,28 @@
 {{#if isExpandable}}
   {{mdl-button for=elementId tagName='label' icon=expandableIcon  hasRipples=false isColored=false}}
   <div class="mdl-textfield__expandable-holder">
-    {{input class="mdl-textfield__input" type=type pattern=pattern id=_inputId disabled=disabled value=value}}
+    {{input class="mdl-textfield__input"
+      type=type
+      pattern=pattern
+      id=_inputId
+      autofocus=autofocus
+      disabled=disabled
+      required=rquired
+      value=value}}
     <label class="mdl-textfield__label" for="{{_inputId}}">{{label}}</label>
     {{#if errorMessage}}
       <span class="mdl-textfield__error">{{errorMessage}}</span>
     {{/if}}
   </div>
 {{else}}
-  {{input class="mdl-textfield__input" type=type pattern=pattern id=_inputId disabled=disabled value=value}}
+  {{input class="mdl-textfield__input"
+    type=type
+    pattern=pattern
+    id=_inputId
+    autofocus=autofocus
+    disabled=disabled
+    required=required
+    value=value}}
   <label class="mdl-textfield__label">{{label}}</label>
   {{#if errorMessage}}
     <span class="mdl-textfield__error">{{errorMessage}}</span>

--- a/tests/dummy/app/templates/snippets/mdl-textfield-basic.hbs
+++ b/tests/dummy/app/templates/snippets/mdl-textfield-basic.hbs
@@ -1,4 +1,4 @@
-{{mdl-textfield label='First Name' value=firstName}}
+{{mdl-textfield label='First Name' value=firstName autofocus=true required=true}}
 {{mdl-textfield label='Last Name' value=lastName isLabelFloating=false}}
 {{mdl-textfield label='Age' type='number'}}
 {{mdl-textfield label='Password' type='password'}}

--- a/tests/dummy/app/templates/snippets/mdl-textfield-textarea.hbs
+++ b/tests/dummy/app/templates/snippets/mdl-textfield-textarea.hbs
@@ -1,2 +1,3 @@
 {{mdl-textarea label="Ramblings"
-	value="This is a lot of text. It's also multi-line, which makes it unsuitable for a single-line input"}}
+	value="This is a lot of text. It's also multi-line, which makes it unsuitable for a single-line input"
+	rows="5"}}

--- a/tests/integration/components/mdl-textarea-test.js
+++ b/tests/integration/components/mdl-textarea-test.js
@@ -29,6 +29,16 @@ test('value bindings', function(assert) {
   assert.equal(this.get('value'), 'bye');
 });
 
+test('textarea attributes', function(assert) {
+  assert.expect(3);
+
+  this.render(hbs`{{mdl-textarea autofocus=true required=true cols="30" rows="5"}}`);
+
+  assert.ok(this.$('textarea').attr('autofocus'));
+  assert.ok(this.$('textarea').attr('required'));
+  assert.equal(this.$('textarea').attr('rows'), 5);
+});
+
 test('html validations', function(assert) {
   assert.expect(2);
 

--- a/tests/integration/components/mdl-textfield-test.js
+++ b/tests/integration/components/mdl-textfield-test.js
@@ -29,6 +29,15 @@ test('value bindings', function(assert) {
   assert.equal(this.get('value'), 'bye');
 });
 
+test('input attributes', function(assert) {
+  assert.expect(2);
+
+  this.render(hbs`{{mdl-textfield autofocus=true required=true}}`);
+
+  assert.ok(this.$('input').attr('autofocus'));
+  assert.ok(this.$('input').attr('required'));
+});
+
 test('html validations', function(assert) {
   assert.expect(2);
 


### PR DESCRIPTION
This PR adds the ability to set `required` or `autofocus` on the `{{mdl-textfield}}` and `{{mdl-textarea}}` components. Additionally, this adds the ability to add a `rows` attr to the `{{mdl-textarea}}` component (omitted `cols` as the `width` CSS definition would override that property).